### PR TITLE
Added getter for email property of an invitee invitation

### DIFF
--- a/src/main/java/com/robinpowered/sdk/model/Invitee.java
+++ b/src/main/java/com/robinpowered/sdk/model/Invitee.java
@@ -230,5 +230,9 @@ public class Invitee implements IdentifiableApiResponseModel {
         public Invitation(String email) {
             this.email = email;
         }
+
+        public String getEmail() {
+            return email;
+        }
     }
 }


### PR DESCRIPTION
Added a getter so you can get the email property of an `Invitee.Invitation`
