### PR TITLE
Feature: Generic IDs for models

### DIFF
--- a/src/main/java/com/robinpowered/sdk/model/Account.java
+++ b/src/main/java/com/robinpowered/sdk/model/Account.java
@@ -6,7 +6,7 @@ import org.joda.time.DateTime;
 /**
  * A base class for a {@link User} or {@link Organization}.
  */
-abstract public class Account implements IdentifiableApiResponseModel {
+abstract public class Account implements IdentifiableApiResponseModel<Integer> {
 
     /**
      * Constants
@@ -44,7 +44,7 @@ abstract public class Account implements IdentifiableApiResponseModel {
     }
 
     @Override
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 

--- a/src/main/java/com/robinpowered/sdk/model/Device.java
+++ b/src/main/java/com/robinpowered/sdk/model/Device.java
@@ -13,7 +13,7 @@ import java.util.List;
  * controlled, such as AV hardware or a thermostat. Common devices include beacons, phones, and
  * motion sensors.
  */
-public class Device implements IdentifiableApiResponseModel {
+public class Device implements IdentifiableApiResponseModel<Integer> {
 
     /**
      * Constants
@@ -55,7 +55,7 @@ public class Device implements IdentifiableApiResponseModel {
     }
 
     @Override
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 

--- a/src/main/java/com/robinpowered/sdk/model/DeviceManifest.java
+++ b/src/main/java/com/robinpowered/sdk/model/DeviceManifest.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * A collection of meta information about a {@link Device}.
  */
-public class DeviceManifest implements IdentifiableApiResponseModel {
+public class DeviceManifest implements IdentifiableApiResponseModel<Integer> {
 
     /**
      * Constants
@@ -52,7 +52,7 @@ public class DeviceManifest implements IdentifiableApiResponseModel {
 
 
     @Override
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 
@@ -121,7 +121,7 @@ public class DeviceManifest implements IdentifiableApiResponseModel {
         return MIME_TYPE;
     }
 
-    public static class Feed implements IdentifiableApiResponseModel {
+    public static class Feed implements IdentifiableApiResponseModel<Integer> {
 
         /**
          * Constants
@@ -158,7 +158,7 @@ public class DeviceManifest implements IdentifiableApiResponseModel {
         }
 
         @Override
-        public int getId() {
+        public Integer getId() {
             return id;
         }
 

--- a/src/main/java/com/robinpowered/sdk/model/Event.java
+++ b/src/main/java/com/robinpowered/sdk/model/Event.java
@@ -19,7 +19,7 @@ import java.util.List;
  *
  * @todo This class needs further design once APIs are fully realized.
  */
-public class Event implements IdentifiableApiResponseModel {
+public class Event implements IdentifiableApiResponseModel<String> {
 
     /**
      * Constants
@@ -67,7 +67,7 @@ public class Event implements IdentifiableApiResponseModel {
      * Properties
      */
 
-    private final int id;
+    private final String id;
     private Integer organizerId;
     private String organizerEmail;
     private Integer creatorId;
@@ -89,12 +89,12 @@ public class Event implements IdentifiableApiResponseModel {
      * Methods
      */
 
-    public Event(int id) {
+    public Event(String id) {
         this.id = id;
     }
 
     @Override
-    public int getId() {
+    public String getId() {
         return id;
     }
 

--- a/src/main/java/com/robinpowered/sdk/model/IdentifiableApiResponseModel.java
+++ b/src/main/java/com/robinpowered/sdk/model/IdentifiableApiResponseModel.java
@@ -3,6 +3,6 @@ package com.robinpowered.sdk.model;
 /**
  * An interface to be implemented by models that contain an {@code id} attribute.
  */
-public interface IdentifiableApiResponseModel extends ApiResponseModel {
-    int getId();
+public interface IdentifiableApiResponseModel<IdType> extends ApiResponseModel {
+    IdType getId();
 }

--- a/src/main/java/com/robinpowered/sdk/model/Invitee.java
+++ b/src/main/java/com/robinpowered/sdk/model/Invitee.java
@@ -10,7 +10,7 @@ import org.joda.time.DateTime;
  *
  * @todo This class needs further design once APIs are fully realized.
  */
-public class Invitee implements IdentifiableApiResponseModel, Invitable {
+public class Invitee implements IdentifiableApiResponseModel<Integer>, Invitable {
 
     /**
      * Constants
@@ -78,7 +78,7 @@ public class Invitee implements IdentifiableApiResponseModel, Invitable {
 
     // Immutable
     private final int id;
-    private final int eventId;
+    private final String eventId;
 
     // Mutable
     private Integer userId;
@@ -98,17 +98,17 @@ public class Invitee implements IdentifiableApiResponseModel, Invitable {
      * Methods
      */
 
-    public Invitee(int id, int eventId) {
+    public Invitee(int id, String eventId) {
         this.id = id;
         this.eventId = eventId;
     }
 
     @Override
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 
-    public Integer getEventId() {
+    public String getEventId() {
         return eventId;
     }
 

--- a/src/main/java/com/robinpowered/sdk/model/Location.java
+++ b/src/main/java/com/robinpowered/sdk/model/Location.java
@@ -10,7 +10,7 @@ import org.joda.time.DateTime;
  * Physically speaking, a location is typically an office or a building and can be associated to a
  * specific physical address.
  */
-public class Location implements IdentifiableApiResponseModel {
+public class Location implements IdentifiableApiResponseModel<Integer> {
 
     /**
      * Constants
@@ -50,7 +50,7 @@ public class Location implements IdentifiableApiResponseModel {
     }
 
     @Override
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 

--- a/src/main/java/com/robinpowered/sdk/model/Organization.java
+++ b/src/main/java/com/robinpowered/sdk/model/Organization.java
@@ -7,7 +7,7 @@ import org.joda.time.DateTime;
  *
  * @todo should isOrganization be exposed in this model?
  */
-public class Organization extends Account implements IdentifiableApiResponseModel {
+public class Organization extends Account implements IdentifiableApiResponseModel<Integer> {
 
     /**
      * Constants

--- a/src/main/java/com/robinpowered/sdk/model/SimpleEvent.java
+++ b/src/main/java/com/robinpowered/sdk/model/SimpleEvent.java
@@ -1,7 +1,6 @@
 package com.robinpowered.sdk.model;
 
 import com.google.common.base.Objects;
-
 import org.joda.time.DateTime;
 
 /**
@@ -24,7 +23,7 @@ public class SimpleEvent implements ApiResponseModel {
      * Properties
      */
 
-    private int id;
+    private String id;
     private DateTime startedAt;
     private DateTime endedAt;
 
@@ -40,7 +39,7 @@ public class SimpleEvent implements ApiResponseModel {
      * @param startedAt When the event started.
      * @param endedAt When the event ended.
      */
-    public SimpleEvent(int id, DateTime startedAt, DateTime endedAt) {
+    public SimpleEvent(String id, DateTime startedAt, DateTime endedAt) {
         this.id = id;
         this.startedAt = startedAt;
         this.endedAt = endedAt;
@@ -58,7 +57,7 @@ public class SimpleEvent implements ApiResponseModel {
         return MIME_TYPE;
     }
 
-    public int getId() {
+    public String getId() {
         return id;
     }
 

--- a/src/main/java/com/robinpowered/sdk/model/Space.java
+++ b/src/main/java/com/robinpowered/sdk/model/Space.java
@@ -13,7 +13,7 @@ import java.util.List;
  * they are the parent model of a {@link Device}, {@link Presence} or {@link Event}. The space model
  * contains references to the current and next events if they exist, as well as its parent location.
  */
-public class Space implements IdentifiableApiResponseModel {
+public class Space implements IdentifiableApiResponseModel<Integer> {
 
     /**
      * Constants
@@ -60,7 +60,7 @@ public class Space implements IdentifiableApiResponseModel {
     }
 
     @Override
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 

--- a/src/main/java/com/robinpowered/sdk/model/User.java
+++ b/src/main/java/com/robinpowered/sdk/model/User.java
@@ -8,7 +8,7 @@ import org.joda.time.DateTime;
  *
  * @todo Does isPending need to be exposed in this model?
  */
-public class User extends Account implements IdentifiableApiResponseModel {
+public class User extends Account implements IdentifiableApiResponseModel<Integer> {
 
     /**
      * Constants

--- a/src/main/java/com/robinpowered/sdk/service/EventService.java
+++ b/src/main/java/com/robinpowered/sdk/service/EventService.java
@@ -5,11 +5,6 @@ import com.robinpowered.sdk.model.ApiResponse;
 import com.robinpowered.sdk.model.Event;
 import com.robinpowered.sdk.model.FreeBusySpace;
 import com.robinpowered.sdk.model.User;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
 import retrofit.Callback;
 import retrofit.http.Body;
 import retrofit.http.GET;
@@ -18,31 +13,35 @@ import retrofit.http.POST;
 import retrofit.http.Path;
 import retrofit.http.QueryMap;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
 public interface EventService {
 
     // Sync
     @GET("/events/{eventId}")
-    ApiResponse<Event> getEvent(@Path("eventId") int eventId, @QueryMap Map<String, Object> options) throws IOException;
+    ApiResponse<Event> getEvent(@Path("eventId") String eventId, @QueryMap Map<String, Object> options) throws IOException;
 
     // Async
     @GET("/events/{eventId}")
-    void getEvent(@Path("eventId") int eventId, @QueryMap Map<String, Object> options, Callback<ApiResponse<Event>> callback);
+    void getEvent(@Path("eventId") String eventId, @QueryMap Map<String, Object> options, Callback<ApiResponse<Event>> callback);
 
     // Sync
     @PATCH("/events/{eventId}")
-    ApiResponse<Event> updateEvent(@Path("eventId") int eventId, @Body Event event) throws IOException;
+    ApiResponse<Event> updateEvent(@Path("eventId") String eventId, @Body Event event) throws IOException;
 
     // Async
     @PATCH("/events/{eventId}")
-    void updateEvent(@Path("eventId") int eventId, @Body Event event, Callback<ApiResponse<Event>> callback);
+    void updateEvent(@Path("eventId") String eventId, @Body Event event, Callback<ApiResponse<Event>> callback);
 
     // Sync
     @DELETE("/events/{eventId}")
-    ApiResponse<Void> deleteEvent(@Path("eventId") int eventId) throws IOException;
+    ApiResponse<Void> deleteEvent(@Path("eventId") String eventId) throws IOException;
 
     // Async
     @DELETE("/events/{eventId}")
-    void deleteEvent(@Path("eventId") int eventId, Callback<ApiResponse<Void>> callback);
+    void deleteEvent(@Path("eventId") String eventId, Callback<ApiResponse<Void>> callback);
 
 
     /**


### PR DESCRIPTION
This PR changes the Identifiable API model to allow for a variable `type` for the ID value. This allows us to use `String` for the `Event` model.
