### PR TITLE
Invitee response status changes

### DIFF
--- a/src/main/java/com/robinpowered/sdk/model/Invitee.java
+++ b/src/main/java/com/robinpowered/sdk/model/Invitee.java
@@ -28,9 +28,17 @@ public class Invitee implements IdentifiableApiResponseModel<Integer>, Invitable
 
         /**
          * The person's response is unknown or not yet set.
+         * @deprecated Use {@link ResponseStatus#UNKNOWN} instead.
          */
+        @Deprecated
         @SerializedName("none")
         NONE("none"),
+
+        /**
+         * The person's response is unknown.
+         */
+        @SerializedName("unknown")
+        UNKNOWN("unknown"),
 
         /**
          * The person has not responded to the event invite.
@@ -49,6 +57,12 @@ public class Invitee implements IdentifiableApiResponseModel<Integer>, Invitable
          */
         @SerializedName("tentative")
         TENTATIVE("tentative"),
+
+        /**
+         * The person has has delegated attendance to another person.
+         */
+        @SerializedName("delegated")
+        DELEGATED("delegated"),
 
         /**
          * The person has accepted the event invite.


### PR DESCRIPTION
Adds support for the new invitee response statuses:
- `NONE` is deprecated
- `UNKNOWN` is added
- `DELEGATED` is added 