### PR TITLE
Fixes our tests for JDK 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 install: mvn install -DskipTests=true -Dgpg.skip=true
 jdk:
-- oraclejdk7
+- openjdk7
 - oraclejdk8
 branches:
   except:


### PR DESCRIPTION
Oracle deprecated JDK 7 in a manner that broke Travis CI support as they can no longer download the SDK. This should fix our tests by using OpenJDK instead.

See issue: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879