### PR TITLE
Add BearerTokenCredential

### DIFF
--- a/src/main/java/com/robinpowered/sdk/RobinApi.java
+++ b/src/main/java/com/robinpowered/sdk/RobinApi.java
@@ -1,7 +1,9 @@
 package com.robinpowered.sdk;
 
 import com.robinpowered.sdk.credential.Credential;
+
 import retrofit.client.Client;
+import com.squareup.okhttp.HttpUrl;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -62,6 +64,18 @@ public class RobinApi {
     public RobinApi(Client httpClient) {
         this.httpClient = httpClient;
     }
+
+    /**
+     * Constructor.
+     *
+     * @param httpClient An HTTP client for performing network requests.
+     * @param endpoint The endpoint used to contact the API.
+     */
+    public RobinApi(Client httpClient, HttpUrl endpoint) {
+        this.httpClient = httpClient;
+        this.serviceFactory = new RobinServiceFactory(endpoint);
+    }
+
 
     /**
      * Constructor.

--- a/src/main/java/com/robinpowered/sdk/credential/BearerTokenCredential.java
+++ b/src/main/java/com/robinpowered/sdk/credential/BearerTokenCredential.java
@@ -1,0 +1,50 @@
+package com.robinpowered.sdk.credential;
+
+public class BearerTokenCredential implements Credential {
+
+    /**
+     * Constants
+     */
+
+    public static final String TYPE = "Bearer";
+
+
+    /**
+     * Properties
+     */
+
+    private String token;
+
+
+    /**
+     * Methods
+     */
+
+    public BearerTokenCredential(String token) {
+        if (token == null) {
+            throw new IllegalArgumentException("The token cannot be null.");
+        }
+
+        this.token = token;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String getValue() {
+        return token;
+    }
+
+    @Override
+    public String getBuiltValue() {
+        return getType() + " " + token;
+    }
+
+    @Override
+    public String toString() {
+        return getBuiltValue();
+    }
+}

--- a/src/test/java/com/robinpowered/sdk/credential/BearerTokenCredentialTest.java
+++ b/src/test/java/com/robinpowered/sdk/credential/BearerTokenCredentialTest.java
@@ -1,0 +1,43 @@
+package com.robinpowered.sdk.credential;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BearerTokenCredentialTest
+{
+    private final String testToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    @Test
+    public void testConstructors()
+    {
+        BearerTokenCredential credential = new BearerTokenCredential(testToken);
+        assertThat(credential.getValue()).isEqualTo(testToken);
+    }
+
+    @Test
+    public void testGetType()
+    {
+        BearerTokenCredential credential = new BearerTokenCredential(testToken);
+        assertThat(credential.getType()).isEqualTo(BearerTokenCredential.TYPE);
+    }
+
+    @Test
+    public void testGetBuiltValue()
+    {
+        BearerTokenCredential credential = new BearerTokenCredential(testToken);
+        assertThat(credential.getBuiltValue()).isEqualTo("Bearer " + testToken);
+    }
+
+    @Test
+    public void testToString()
+    {
+        BearerTokenCredential credential = new BearerTokenCredential(testToken);
+        assertThat(credential.toString()).isEqualTo("Bearer " + testToken);
+    }
+}


### PR DESCRIPTION
Adds the ability to use Bearer authentication against the API.

Also adds a constructor to `RobinApi` to support non-default API endpoints.